### PR TITLE
#154 replaced flatbuffers:: with ::flatbuffers::

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -66,9 +66,9 @@ static std::string GenTypeWire(const Parser &parser, const Type &type,
 static std::string GenTypePointer(const Parser &parser, const Type &type) {
   switch (type.base_type) {
     case BASE_TYPE_STRING:
-      return "flatbuffers::String";
+      return "::flatbuffers::String";
     case BASE_TYPE_VECTOR:
-      return "flatbuffers::Vector<" +
+      return "::flatbuffers::Vector<" +
              GenTypeWire(parser, type.VectorType(), "", false) + ">";
     case BASE_TYPE_STRUCT: {
       return WrapInNameSpace(parser, *type.struct_def);
@@ -88,7 +88,7 @@ static std::string GenTypeWire(const Parser &parser, const Type &type,
     ? GenTypeBasic(parser, type, real_enum) + postfix
     : IsStruct(type)
       ? "const " + GenTypePointer(parser, type) + " *"
-      : "flatbuffers::Offset<" + GenTypePointer(parser, type) + ">" + postfix;
+      : "::flatbuffers::Offset<" + GenTypePointer(parser, type) + ">" + postfix;
 }
 
 // Return a C++ type for any type (scalar/pointer) that reflects its
@@ -98,7 +98,7 @@ static std::string GenTypeSize(const Parser &parser, const Type &type) {
     ? GenTypeBasic(parser, type, false)
     : IsStruct(type)
       ? GenTypePointer(parser, type)
-      : "flatbuffers::uoffset_t";
+      : "::flatbuffers::uoffset_t";
 }
 
 // Return a C++ type for any type (scalar/pointer) specifically for
@@ -171,7 +171,7 @@ static void GenEnum(const Parser &parser, EnumDef &enum_def,
     // has been corrupted, since the verifiers will simply fail when called
     // on the wrong type.
     auto signature = "inline bool Verify" + enum_def.name +
-                     "(flatbuffers::Verifier &verifier, " +
+                     "(::flatbuffers::Verifier &verifier, " +
                      "const void *union_obj, " + enum_def.name + " type)";
     code += signature + ";\n\n";
     code_post += signature + " {\n  switch (type) {\n";
@@ -214,7 +214,7 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
   // type name() const { return GetField<type>(offset, defaultval); }
   GenComment(struct_def.doc_comment, code_ptr);
   code += "struct " + struct_def.name;
-  code += " FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table";
+  code += " FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table";
   code += " {\n";
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
@@ -242,7 +242,7 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
         auto nested_root = parser.structs_.Lookup(nested->constant);
         assert(nested_root);  // Guaranteed to exist by parser.
         code += "  const " + nested_root->name + " *" + field.name;
-        code += "_nested_root() const { return flatbuffers::GetRoot<";
+        code += "_nested_root() const { return ::flatbuffers::GetRoot<";
         code += nested_root->name + ">(" + field.name + "()->Data()); }\n";
       }
       // Generate a comparison function for this field if it is a key.
@@ -267,7 +267,7 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
   }
   // Generate a verifier function that can check a buffer from an untrusted
   // source will never cause reads outside the buffer.
-  code += "  bool Verify(flatbuffers::Verifier &verifier) const {\n";
+  code += "  bool Verify(::flatbuffers::Verifier &verifier) const {\n";
   code += "    return VerifyTableStart(verifier)";
   std::string prefix = " &&\n           ";
   for (auto it = struct_def.fields.vec.begin();
@@ -325,8 +325,8 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
   // Generate a builder struct, with methods of the form:
   // void add_name(type name) { fbb_.AddElement<type>(offset, name, default); }
   code += "struct " + struct_def.name;
-  code += "Builder {\n  flatbuffers::FlatBufferBuilder &fbb_;\n";
-  code += "  flatbuffers::uoffset_t start_;\n";
+  code += "Builder {\n  ::flatbuffers::FlatBufferBuilder &fbb_;\n";
+  code += "  ::flatbuffers::uoffset_t start_;\n";
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
        ++it) {
@@ -351,12 +351,12 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
     }
   }
   code += "  " + struct_def.name;
-  code += "Builder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) ";
+  code += "Builder(::flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) ";
   code += "{ start_ = fbb_.StartTable(); }\n";
   code += "  " + struct_def.name + "Builder &operator=(const ";
   code += struct_def.name + "Builder &);\n";
-  code += "  flatbuffers::Offset<" + struct_def.name;
-  code += "> Finish() {\n    auto o = flatbuffers::Offset<" + struct_def.name;
+  code += "  ::flatbuffers::Offset<" + struct_def.name;
+  code += "> Finish() {\n    auto o = ::flatbuffers::Offset<" + struct_def.name;
   code += ">(fbb_.EndTable(start_, ";
   code += NumToString(struct_def.fields.vec.size()) + "));\n";
   for (auto it = struct_def.fields.vec.begin();
@@ -372,9 +372,9 @@ static void GenTable(const Parser &parser, StructDef &struct_def,
 
   // Generate a convenient CreateX function that uses the above builder
   // to create a table in one go.
-  code += "inline flatbuffers::Offset<" + struct_def.name + "> Create";
+  code += "inline ::flatbuffers::Offset<" + struct_def.name + "> Create";
   code += struct_def.name;
-  code += "(flatbuffers::FlatBufferBuilder &_fbb";
+  code += "(::flatbuffers::FlatBufferBuilder &_fbb";
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
        ++it) {
@@ -471,7 +471,7 @@ static void GenStruct(const Parser &parser, StructDef &struct_def,
     if (it != struct_def.fields.vec.begin()) code += ", ";
     code += field.name + "_(";
     if (IsScalar(field.value.type.base_type)) {
-      code += "flatbuffers::EndianScalar(";
+      code += "::flatbuffers::EndianScalar(";
       code += GenUnderlyingCast(parser, field, false, field.name);
       code += "))";
     } else {
@@ -496,7 +496,7 @@ static void GenStruct(const Parser &parser, StructDef &struct_def,
   code += " }\n\n";
 
   // Generate accessor methods of the form:
-  // type name() const { return flatbuffers::EndianScalar(name_); }
+  // type name() const { return ::flatbuffers::EndianScalar(name_); }
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
        ++it) {
@@ -507,7 +507,7 @@ static void GenStruct(const Parser &parser, StructDef &struct_def,
     code += field.name + "() const { return ";
     code += GenUnderlyingCast(parser, field, true,
       IsScalar(field.value.type.base_type)
-        ? "flatbuffers::EndianScalar(" + field.name + "_)"
+        ? "::flatbuffers::EndianScalar(" + field.name + "_)"
         : field.name + "_");
     code += "; }\n";
   }
@@ -622,8 +622,8 @@ std::string GenerateCPP(const Parser &parser,
       int num_includes = 0;
       for (auto it = parser.included_files_.begin();
            it != parser.included_files_.end(); ++it) {
-        auto basename = flatbuffers::StripPath(
-                          flatbuffers::StripExtension(it->first));
+        auto basename = ::flatbuffers::StripPath(
+                          ::flatbuffers::StripExtension(it->first));
         if (basename != file_name) {
           code += "#include \"" + basename + "_generated.h\"\n";
           num_includes++;
@@ -652,13 +652,13 @@ std::string GenerateCPP(const Parser &parser,
       // The root datatype accessor:
       code += "inline const " + name + " *Get";
       code += name;
-      code += "(const void *buf) { return flatbuffers::GetRoot<";
+      code += "(const void *buf) { return ::flatbuffers::GetRoot<";
       code += name + ">(buf); }\n\n";
 
       // The root verifier:
       code += "inline bool Verify";
       code += name;
-      code += "Buffer(flatbuffers::Verifier &verifier) { "
+      code += "Buffer(::flatbuffers::Verifier &verifier) { "
               "return verifier.VerifyBuffer<";
       code += name + ">(); }\n\n";
 
@@ -670,14 +670,14 @@ std::string GenerateCPP(const Parser &parser,
 
         // Check if a buffer has the identifier.
         code += "inline bool " + name;
-        code += "BufferHasIdentifier(const void *buf) { return flatbuffers::";
+        code += "BufferHasIdentifier(const void *buf) { return ::flatbuffers::";
         code += "BufferHasIdentifier(buf, ";
         code += name + "Identifier()); }\n\n";
       }
 
       // Finish a buffer with a given root object:
       code += "inline void Finish" + name;
-      code += "Buffer(flatbuffers::FlatBufferBuilder &fbb, flatbuffers::Offset<";
+      code += "Buffer(::flatbuffers::FlatBufferBuilder &fbb, ::flatbuffers::Offset<";
       code += name + "> root) { fbb.Finish(root";
       if (parser.file_identifier_.length())
         code += ", " + name + "Identifier()";
@@ -714,8 +714,8 @@ std::string CPPMakeRule(const Parser &parser,
                         const std::string &path,
                         const std::string &file_name,
                         const GeneratorOptions & /*opts*/) {
-  std::string filebase = flatbuffers::StripPath(
-      flatbuffers::StripExtension(file_name));
+  std::string filebase = ::flatbuffers::StripPath(
+      ::flatbuffers::StripExtension(file_name));
   std::string make_rule = GeneratedFileName(path, filebase) + ": ";
   auto included_files = parser.GetIncludedFilesRecursive(file_name);
   for (auto it = included_files.begin();


### PR DESCRIPTION
This should resolve the inner namespace error, such as declaring
namespace my.flatbuffers;
in a *.fbs file.
